### PR TITLE
Added workaround for the RLS line-ending issue.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force LF line endings, because of an RLS issue: https://github.com/rust-lang-nursery/rls/issues/1096
+* text eol=lf


### PR DESCRIPTION
There was some pretty bad glitches regarding RLS' autocomplete because of a bug with Windows-style line endings. [(#1096)]( https://github.com/rust-lang-nursery/rls/issues/1096)

The best workaround seemed to be adding a `.gitattributes` file to force the line-endings to `LF`. Doing this turned the autocomplete from being essentially useless back to normal.